### PR TITLE
Fixed issue #3023: Typo in "Create Repository" doc

### DIFF
--- a/doc/source/en/TortoiseGit/tgit_dug/dug_create.xml
+++ b/doc/source/en/TortoiseGit/tgit_dug/dug_create.xml
@@ -23,7 +23,7 @@
 		</figure>
   </para>
   <para>
-		You can choose here between a bare and normal git repository. A normal repository has a working tree attached to which files can be checkout out and committed hwreas a bare repository only can be pushed to and pulled from.
+		You can choose here between a bare and normal git repository. A normal repository has a working tree attached to which files can be checkout out and committed whereas a bare repository only can be pushed to and pulled from.
 		After a (non bare) repository is created a messagebox will be shown:
 		<figure id="tgit-dug-create-dia-created">
 			<title>Successfull repository creation message</title>


### PR DESCRIPTION

Corrected small typo from "hwreas" to "whereas" (2nd paragraph, 2nd sentence)
Signed-off-by: Christopher C. Jessamy <cjessamy@gmail.com>